### PR TITLE
Feat padding column gap options

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,22 @@ $grid-responsive-column-counts: (
   sm: 4,
 );
 
+/// NB! You can set this up however you want but the key names must
+/// match responsive breakpoint keys(from above) to work properly!
+$grid-responsive-column-gap: (
+  md: $grid-column-gap,
+  sm: $grid-column-gap,
+) !default;
+
 /// Defaults for container() mixin
 $container-width: 1200px;
 $container-padding: 48px;
-$container-padding-sm: 12px; /// at the "sm" breakpoint
+/// NB! You can set this up however you want but the key names must
+/// match responsive breakpoint keys(from above) to work properly!
+$container-responsive-padding: (
+  md: $container-padding,
+  sm: 12px,
+) !default; /// at the "md" and sm" breakpoints
 ```
 
 Here's all the mixins with default args:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $grid-responsive-column-counts: (
 $grid-responsive-column-gap: (
   md: $grid-column-gap,
   sm: $grid-column-gap,
-) !default;
+) !default; /// at the "md" and sm" breakpoints
 
 /// Defaults for container() mixin
 $container-width: 1200px;

--- a/README.md
+++ b/README.md
@@ -120,10 +120,8 @@ $grid-responsive-column-gap: (
 /// Defaults for container() mixin
 $container-width: 1200px;
 $container-padding: 48px;
-$container-padding-sm: 12px; /// Deprecation warning: Use $container-responsive-padding instead
 /// NB! You can set this up however you want but the key names must
 /// match responsive breakpoint keys(from above) to work properly!
-/// $container-responsive-padding will override legacy $container-padding-sm
 $container-responsive-padding: (
   md: $container-padding,
   sm: 12px,

--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ $grid-responsive-column-gap: (
 /// Defaults for container() mixin
 $container-width: 1200px;
 $container-padding: 48px;
+$container-padding-sm: 12px; /// Deprecation warning: Use $container-responsive-padding instead
 /// NB! You can set this up however you want but the key names must
 /// match responsive breakpoint keys(from above) to work properly!
+/// $container-responsive-padding will override legacy $container-padding-sm
 $container-responsive-padding: (
   md: $container-padding,
   sm: 12px,

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -12,8 +12,6 @@
 $grid-column-count: 12 !default;
 $grid-column-gap: 24px !default;
 $grid-row-gap: 24 !default;
-$grid-row-gap-md: $grid-row-gap !default;
-$grid-row-gap-sm: $grid-row-gap !default;
 $grid-responsive-column-counts: (
   md: 8,
   sm: 4,

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -95,6 +95,7 @@ $grid-responsive-column-gap: (
 
 $container-width: 1200px !default;
 $container-padding: 48px !default;
+$container-padding-sm: 12px !default;
 $container-responsive-padding: (
   md: $container-padding,
   sm: 12px,
@@ -111,6 +112,17 @@ $container-responsive-padding: (
     max-width: unset;
     padding-right: 0;
     padding-left: 0;
+  }
+
+  @include media-breakpoint-down(sm) {
+    padding-right: $container-padding-sm;
+    padding-left: $container-padding-sm;
+
+    .container & {
+      max-width: unset;
+      padding-right: 0;
+      padding-left: 0;
+    }
   }
 
   @each $breakpoint, $padding in $container-responsive-padding {

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -95,7 +95,6 @@ $grid-responsive-column-gap: (
 
 $container-width: 1200px !default;
 $container-padding: 48px !default;
-$container-padding-sm: 12px !default;
 $container-responsive-padding: (
   md: $container-padding,
   sm: 12px,
@@ -112,17 +111,6 @@ $container-responsive-padding: (
     max-width: unset;
     padding-right: 0;
     padding-left: 0;
-  }
-
-  @include media-breakpoint-down(sm) {
-    padding-right: $container-padding-sm;
-    padding-left: $container-padding-sm;
-
-    .container & {
-      max-width: unset;
-      padding-right: 0;
-      padding-left: 0;
-    }
   }
 
   @each $breakpoint, $padding in $container-responsive-padding {

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -12,9 +12,15 @@
 $grid-column-count: 12 !default;
 $grid-column-gap: 24px !default;
 $grid-row-gap: 24 !default;
+$grid-row-gap-md: $grid-row-gap !default;
+$grid-row-gap-sm: $grid-row-gap !default;
 $grid-responsive-column-counts: (
   md: 8,
   sm: 4,
+) !default;
+$grid-responsive-column-gap: (
+  md: $grid-column-gap,
+  sm: $grid-column-gap,
 ) !default;
 
 @mixin grid($columns: $grid-column-count, $responsive-columns: true) {
@@ -26,6 +32,12 @@ $grid-responsive-column-counts: (
     @each $breakpoint, $column-count in $grid-responsive-column-counts {
       @include media-breakpoint-down($breakpoint) {
         grid-template-columns: repeat($column-count, 1fr);
+      }
+    }
+
+    @each $breakpoint, $column-gap in $grid-responsive-column-gap {
+      @include media-breakpoint-down($breakpoint) {
+        column-gap: $column-gap;
       }
     }
   }
@@ -82,11 +94,13 @@ $grid-responsive-column-counts: (
 /// @param {Number} $columns - Number of columns in the grid
 /// @require $container-width
 /// @require $container-padding
-/// @require $container-padding-sm
 
 $container-width: 1200px !default;
 $container-padding: 48px !default;
-$container-padding-sm: 12px !default;
+$container-responsive-padding: (
+  md: $container-padding,
+  sm: 12px,
+) !default;
 
 @mixin container() {
   max-width: $container-width + ($container-padding * 2);
@@ -101,14 +115,16 @@ $container-padding-sm: 12px !default;
     padding-left: 0;
   }
 
-  @include media-breakpoint-down(sm) {
-    padding-right: $container-padding-sm;
-    padding-left: $container-padding-sm;
+  @each $breakpoint, $padding in $container-responsive-padding {
+    @include media-breakpoint-down($breakpoint) {
+      padding-right: $padding;
+      padding-left: $padding;
 
-    .container & {
-      max-width: unset;
-      padding-right: 0;
-      padding-left: 0;
+      .container & {
+        max-width: unset;
+        padding-right: 0;
+        padding-left: 0;
+      }
     }
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -3,6 +3,7 @@
     <head>
         <title>Nought Sass Mixins Test Page</title>
         <link rel="stylesheet" href="./dist/test.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>
         <main class="container-grid">


### PR DESCRIPTION
[ENG-1534](https://linear.app/alephsf/issue/ENG-1534/add-additional-options-to-nought-sass-mixins-and-update-package). Adds support to set container padding and grid column gap at any breakpoint without deprecating `$container-padding-sm`. Or should I deprecate it and bump the package up a major version to 2.0.0? I'll run `standard-version` after this is merged in.